### PR TITLE
update boost download url

### DIFF
--- a/cmake/boost.cmake
+++ b/cmake/boost.cmake
@@ -1,5 +1,5 @@
 # Copyright (c) 2014, 2023, Oracle and/or its affiliates.
-# 
+#
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License, version 2.0,
 # as published by the Free Software Foundation.
@@ -41,7 +41,7 @@
 SET(BOOST_PACKAGE_NAME "boost_1_77_0")
 SET(BOOST_TARBALL "${BOOST_PACKAGE_NAME}.tar.bz2")
 SET(BOOST_DOWNLOAD_URL
-  "https://boostorg.jfrog.io/artifactory/main/release/1.77.0/source/${BOOST_TARBALL}"
+  "https://archives.boost.io/release/1.77.0/source/${BOOST_TARBALL}"
   )
 
 SET(OLD_PACKAGE_NAMES


### PR DESCRIPTION
Part of https://github.com/Shopify/db-core-mysql/issues/1741

This PR updates the boost URL used during build. This is so that we can build percona-server successfully 