### PR TITLE
Return correct memory buffer size

### DIFF
--- a/storage/rocksdb/ha_rocksdb.cc
+++ b/storage/rocksdb/ha_rocksdb.cc
@@ -16668,6 +16668,10 @@ double ha_rocksdb::read_time(uint index, uint ranges, ha_rows rows) {
   DBUG_RETURN((rows / 20.0) + 1);
 }
 
+longlong ha_rocksdb::get_memory_buffer_size() const {
+  return rocksdb_block_cache_size;
+}
+
 void ha_rocksdb::print_error(int error, myf errflag) {
   switch (error) {
     case HA_ERR_ROCKSDB_STATUS_BUSY:

--- a/storage/rocksdb/ha_rocksdb.h
+++ b/storage/rocksdb/ha_rocksdb.h
@@ -612,6 +612,7 @@ class ha_rocksdb : public my_core::handler, public blob_buffer {
   }
 
   virtual double read_time(uint, uint, ha_rows rows) override;
+  longlong get_memory_buffer_size() const override;
   virtual void print_error(int error, myf errflag) override;
 
   int open(const char *const name, int mode, uint test_if_locked,


### PR DESCRIPTION
Part of https://github.com/Shopify/db-core-mysql/issues/1896

This PR makes myrocks engine return correct memory buffer sizes (== block_cache_size). As mentioned in the issue, this is needed by the optimizer for query planning and the default fallback of 100MB leads to inaccurate estimations, leading to suboptimal plans. 


